### PR TITLE
TypeError: DeduplicationHandler::__construct(): Argument #3 ($store) must be of type string, null given

### DIFF
--- a/src/Deduplication/DeduplicationHandler.php
+++ b/src/Deduplication/DeduplicationHandler.php
@@ -15,7 +15,7 @@ class DeduplicationHandler extends BufferHandler
     public function __construct(
         HandlerInterface $handler,
         protected SignatureGeneratorInterface $signatureGenerator,
-        string $store = 'default',
+        ?string $store = 'default',
         string $prefix = 'github-monolog:dedup:',
         int $ttl = 60,
         int|string|Level $level = Level::Error,


### PR DESCRIPTION
```php
// config
'github' => [
    'driver' => 'custom',
    'via'    => Naoray\LaravelGithubMonolog\GithubIssueHandlerFactory::class,
    'repo'   => env('GITHUB_REPOSITORY'),
    'token'  => env('GITHUB_TOKEN'),
    'level'  => env('LOG_LEVEL', 'error'),

    'deduplication' => [
        'store'  => null,
        'prefix' => 'github-monolog:',
        'time'   => 3600,
    ],

    'buffer' => [
        'limit'             => 20,
        'flush_on_overflow' => false,
    ],
],
```
```log
[2025-03-11 17:19:59] laravel.EMERGENCY: Unable to create configured logger. Using emergency logger. {"exception":"[object] (TypeError(code: 0): Naoray\\LaravelGithubMonolog\\Deduplication\\DeduplicationHandler::__construct(): Argument #3 ($store) must be of type string, null given, called in D:\\domains\\app\\vendor\\naoray\\laravel-github-monolog\\src\\GithubIssueHandlerFactory.php on line 72 at D:\\domains\\app\\vendor\\naoray\\laravel-github-monolog\\src\\Deduplication\\DeduplicationHandler.php:15)
[stacktrace]
#0 D:\\domains\\app\\vendor\\naoray\\laravel-github-monolog\\src\\GithubIssueHandlerFactory.php(72): Naoray\\LaravelGithubMonolog\\Deduplication\\DeduplicationHandler->__construct(Object(Naoray\\LaravelGithubMonolog\\Issues\\Handler), Object(Naoray\\LaravelGithubMonolog\\Deduplication\\DefaultSignatureGenerator), NULL, 'github-monolog:', 3600, 'error', 20, true, false)
#1 D:\\domains\\app\\vendor\\naoray\\laravel-github-monolog\\src\\GithubIssueHandlerFactory.php(26): Naoray\\LaravelGithubMonolog\\GithubIssueHandlerFactory->wrapWithDeduplication(Object(Naoray\\LaravelGithubMonolog\\Issues\\Handler), Array)
#2 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Log\\LogManager.php(260): Naoray\\LaravelGithubMonolog\\GithubIssueHandlerFactory->__invoke(Array)
#3 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Log\\LogManager.php(233): Illuminate\\Log\\LogManager->createCustomDriver(Array)
#4 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Log\\LogManager.php(139): Illuminate\\Log\\LogManager->resolve('github', Array)
#5 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Log\\LogManager.php(126): Illuminate\\Log\\LogManager->get('github')
#6 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Log\\LogManager.php(115): Illuminate\\Log\\LogManager->driver('github')
#7 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Support\\Facades\\Facade.php(361): Illuminate\\Log\\LogManager->channel('github')
#8 D:\\domains\\app\\routes\\console.php(13): Illuminate\\Support\\Facades\\Facade::__callStatic('channel', Array)
#9 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Container\\BoundMethod.php(36): Illuminate\\Foundation\\Console\\ClosureCommand->{closure:D:\\domains\\app\\routes\\console.php:12}()
#10 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Container\\Util.php(43): Illuminate\\Container\\BoundMethod::{closure:Illuminate\\Container\\BoundMethod::call():35}()
#11 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Container\\BoundMethod.php(83): Illuminate\\Container\\Util::unwrapIfClosure(Object(Closure))
#12 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Container\\BoundMethod.php(35): Illuminate\\Container\\BoundMethod::callBoundMethod(Object(Illuminate\\Foundation\\Application), Object(Closure), Object(Closure))
#13 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Container\\Container.php(754): Illuminate\\Container\\BoundMethod::call(Object(Illuminate\\Foundation\\Application), Object(Closure), Array, NULL)
#14 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Foundation\\Console\\ClosureCommand.php(63): Illuminate\\Container\\Container->call(Object(Closure), Array)
#15 D:\\domains\\app\\vendor\\symfony\\console\\Command\\Command.php(279): Illuminate\\Foundation\\Console\\ClosureCommand->execute(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Illuminate\\Console\\OutputStyle))
#16 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Console\\Command.php(182): Symfony\\Component\\Console\\Command\\Command->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Illuminate\\Console\\OutputStyle))
#17 D:\\domains\\app\\vendor\\symfony\\console\\Application.php(1094): Illuminate\\Console\\Command->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#18 D:\\domains\\app\\vendor\\symfony\\console\\Application.php(342): Symfony\\Component\\Console\\Application->doRunCommand(Object(Illuminate\\Foundation\\Console\\ClosureCommand), Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#19 D:\\domains\\app\\vendor\\symfony\\console\\Application.php(193): Symfony\\Component\\Console\\Application->doRun(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#20 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Foundation\\Console\\Kernel.php(198): Symfony\\Component\\Console\\Application->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#21 D:\\domains\\app\\vendor\\laravel\\framework\\src\\Illuminate\\Foundation\\Application.php(1235): Illuminate\\Foundation\\Console\\Kernel->handle(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#22 D:\\domains\\app\\artisan(16): Illuminate\\Foundation\\Application->handleCommand(Object(Symfony\\Component\\Console\\Input\\ArgvInput))
#23 {main}
"} 
```
```php
Artisan::command('foo', function (): void {
    Log::channel('github')->error('it is a log');
});
```
![image](https://github.com/user-attachments/assets/0b3e92ea-ebc5-4256-9647-74bd3161087d)
https://github.com/Naoray/laravel-github-monolog/blob/main/UPGRADE.md