### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,13 +30,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-github-monolog` will be documented in this file.
 
+## Unreleased
+
+### What's Changed
+
+* Add Laravel 13 support
+
 ## v3.8.0 - 2026-02-08
 
 ### What's Changed

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
     "laravel/pint": "^1.14",
     "nunomaduro/collision": "^8.1.1",
     "orchestra/testbench": "^11.0||^10.0||^9.0.0",
-    "pestphp/pest": "^3.0",
-    "pestphp/pest-plugin-arch": "^3.0",
-    "pestphp/pest-plugin-laravel": "^3.0",
+    "pestphp/pest": "^3.0||^4.0",
+    "pestphp/pest-plugin-arch": "^3.0||^4.0",
+    "pestphp/pest-plugin-laravel": "^3.0||^4.0",
     "phpstan/extension-installer": "^1.3",
     "phpstan/phpstan-deprecation-rules": "^2.0",
     "phpstan/phpstan-phpunit": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
   ],
   "require": {
     "php": "^8.3",
-    "illuminate/cache": "^11.0||^12.0",
-    "illuminate/contracts": "^11.0||^12.0",
-    "illuminate/filesystem": "^11.0||^12.0",
-    "illuminate/http": "^11.0||^12.0",
-    "illuminate/support": "^11.37||^12.0",
+    "illuminate/cache": "^11.0||^12.0||^13.0",
+    "illuminate/contracts": "^11.0||^12.0||^13.0",
+    "illuminate/filesystem": "^11.0||^12.0||^13.0",
+    "illuminate/http": "^11.0||^12.0||^13.0",
+    "illuminate/support": "^11.37||^12.0||^13.0",
     "monolog/monolog": "^3.6"
   },
   "require-dev": {
@@ -31,7 +31,7 @@
     "laravel/nightwatch": "^1.21",
     "laravel/pint": "^1.14",
     "nunomaduro/collision": "^8.1.1",
-    "orchestra/testbench": "^10.0||^9.0.0",
+    "orchestra/testbench": "^11.0||^10.0||^9.0.0",
     "pestphp/pest": "^3.0",
     "pestphp/pest-plugin-arch": "^3.0",
     "pestphp/pest-plugin-laravel": "^3.0",


### PR DESCRIPTION
## Summary

- Add `^13.0` to all `illuminate/*` dependency constraints
- Add `orchestra/testbench` `^11.0` for Laravel 13 test support
- Add Laravel 13 to CI test matrix (with testbench 11)

No source code changes required. Reviewed the [Laravel 13 upgrade guide](https://laravel.com/docs/13.x/upgrade) and confirmed none of the breaking changes affect this package.