### PR TITLE
Strip hidden tracing context during dehydration

### DIFF
--- a/src/GithubMonologServiceProvider.php
+++ b/src/GithubMonologServiceProvider.php
@@ -47,16 +47,30 @@ class GithubMonologServiceProvider extends ServiceProvider
                 'inertia',
             ];
 
+            // Tracing collectors store most of their payloads as hidden
+            // context, so we have to clear both the visible and hidden stores.
+            // Otherwise the request payload (which may contain an unserializable
+            // UploadedFile) is serialized into job payloads and throws.
             foreach ($keysToForget as $key) {
                 if ($context->has($key)) {
                     $context->forget($key);
                 }
+
+                if ($context->hasHidden($key)) {
+                    $context->forgetHidden($key);
+                }
             }
 
-            // Clean up prefixed keys
+            // Clean up prefixed keys from both the visible and hidden stores.
             foreach (array_keys($context->all()) as $key) {
                 if (str_starts_with($key, 'outgoing_request.')) {
                     $context->forget($key);
+                }
+            }
+
+            foreach (array_keys($context->allHidden()) as $key) {
+                if (str_starts_with($key, 'outgoing_request.')) {
+                    $context->forgetHidden($key);
                 }
             }
         });

--- a/tests/ContextDehydrationTest.php
+++ b/tests/ContextDehydrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Context;
+
+beforeEach(function () {
+    Context::flush();
+});
+
+afterEach(function () {
+    Context::flush();
+});
+
+it('strips hidden tracing context so job payloads can be serialized', function () {
+    // RequestDataCollector stores the request payload as hidden context, and
+    // $request->all() merges raw UploadedFile instances into the body. Those
+    // cannot be serialized, so dehydrating must remove the hidden 'request' key.
+    Context::addHidden('request', [
+        'body' => [
+            'file' => UploadedFile::fake()->create('audio.mp3', 100),
+        ],
+    ]);
+
+    // dehydrate() serializes both the visible and hidden stores. Without the
+    // fix this throws "Serialization of 'Illuminate\Http\UploadedFile' is not allowed".
+    $dehydrated = Context::dehydrate();
+
+    expect($dehydrated['hidden'] ?? [])->not->toHaveKey('request');
+});
+
+it('strips hidden tracing keys from dehydrated context', function () {
+    Context::addHidden('queries', ['select * from users']);
+    Context::addHidden('session', ['foo' => 'bar']);
+    Context::addHidden('breadcrumbs', [['message' => 'clicked']]);
+    Context::addHidden('outgoing_requests', [['url' => 'https://example.com']]);
+    Context::addHidden('outgoing_request.abc123', ['url' => 'https://example.com']);
+
+    $dehydrated = Context::dehydrate();
+    $hidden = $dehydrated['hidden'] ?? [];
+
+    expect($hidden)
+        ->not->toHaveKey('queries')
+        ->not->toHaveKey('session')
+        ->not->toHaveKey('breadcrumbs')
+        ->not->toHaveKey('outgoing_requests')
+        ->not->toHaveKey('outgoing_request.abc123');
+});
+
+it('keeps unrelated hidden context untouched', function () {
+    Context::addHidden('keep_me', ['important' => true]);
+
+    $dehydrated = Context::dehydrate();
+    $hidden = $dehydrated['hidden'] ?? [];
+
+    expect($hidden)->toHaveKey('keep_me');
+});


### PR DESCRIPTION
The context dehydration guard registered in `GithubMonologServiceProvider::registerContextDehydration()` only forgets keys from the **visible** context store (`$context->has()` / `$context->forget()`).

However, the tracing collectors store most of their payloads as **hidden** context:

- `RequestDataCollector` → `Context::addHidden('request', ...)`
- `SessionCollector` → `Context::addHidden('session', ...)`
- `QueryCollector` → `Context::addHidden('queries', ...)`
- `BreadcrumbCollector` → `Context::addHidden('breadcrumbs', ...)`
- `OutgoingRequestResponseCollector` / `OutgoingRequestSendingCollector` → `Context::addHidden('outgoing_requests', ...)` and `outgoing_request.{id}`

Since `Context::dehydrate()` serializes **both** the visible and hidden stores, none of these payloads were actually being stripped from queued job payloads.

### Impact

`RequestDataCollector` stores `'body' => $this->redactPayload($request->all())`, and `$request->all()` merges raw `UploadedFile` instances into the body. When any job is dispatched during a request that included a file upload, dehydration tries to serialize that `UploadedFile` and throws:

```
Serialization of 'Illuminate\Http\UploadedFile' is not allowed
```

This reproduces reliably when uploading files through a CMS control panel (e.g. Statamic) where a job is dispatched after the response.

### Fix

Forget the listed keys (and the `outgoing_request.*` prefixed keys) from the **hidden** store as well, so the guard works as intended.

### Tests

Added `tests/ContextDehydrationTest.php` covering:
- A hidden `request` payload containing an `UploadedFile` no longer breaks `Context::dehydrate()`.
- The hidden tracing keys (`queries`, `session`, `breadcrumbs`, `outgoing_requests`, `outgoing_request.*`) are stripped.
- Unrelated hidden context is left untouched.

Full suite (347 tests) passes; Pint and PHPStan are clean.